### PR TITLE
Determine correct DTB automatically and power on wifi adapter, in U-Boot

### DIFF
--- a/layers/meta-balena-tm3/recipes-bsp/u-boot/files/boot.cmd
+++ b/layers/meta-balena-tm3/recipes-bsp/u-boot/files/boot.cmd
@@ -18,6 +18,10 @@ else
     fi;
 fi;
 
+regulator dev vcc-wifi
+regulator value 3300000
+regulator enable
+
 load mmc ${mmc_bootdev}:1 ${fdt_addr_r} ${fdt_file}
 load ${resin_dev_type} ${resin_dev_index}:${resin_root_part} ${resin_kernel_load_addr} /boot/Image
 booti ${resin_kernel_load_addr} - ${fdt_addr_r}

--- a/layers/meta-balena-tm3/recipes-bsp/u-boot/files/boot.cmd
+++ b/layers/meta-balena-tm3/recipes-bsp/u-boot/files/boot.cmd
@@ -1,6 +1,23 @@
-load mmc ${mmc_bootdev}:1 ${fdt_addr_r} tm3-hb8-7-c.dtb
 setenv resin_kernel_load_addr ${kernel_addr_r}
 run resin_set_kernel_root
 setenv bootargs "${bootargs} ${resin_kernel_root} console=ttyS0 console=tty1 rootwait"
+
+if test -n ${custom_fdt_file}; then
+    setenv fdt_file ${custom_fdt_file};
+else
+    setenv hb hb8;
+    i2c dev 0;
+    if i2c probe 0x38; then
+        setenv fdt_file tm3-${hb}-7-c.dtb;
+    elif i2c probe 0x41; then
+        setenv fdt_file tm3-${hb}-9-c.dtb;
+    elif i2c probe 0x2a; then
+        setenv fdt_file tm3-${hb}-12-c.dtb;
+    else
+        setenv fdt_file tm3-${hb}-7-r.dtb;
+    fi;
+fi;
+
+load mmc ${mmc_bootdev}:1 ${fdt_addr_r} ${fdt_file}
 load ${resin_dev_type} ${resin_dev_index}:${resin_root_part} ${resin_kernel_load_addr} /boot/Image
 booti ${resin_kernel_load_addr} - ${fdt_addr_r}

--- a/layers/meta-balena-tm3/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-tm3/recipes-core/images/balena-image.inc
@@ -11,7 +11,10 @@ BALENA_BOOT_PARTITION_FILES:append = " \
     u-boot-sunxi-with-spl.bin:/u-boot-sunxi-with-spl.bin \
     boot.scr:/boot.scr \
     ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
-    tm3-hb8-7-c.dtb:/tm3-hb8-7-c.dtb"
+    tm3-hb8-7-c.dtb:/tm3-hb8-7-c.dtb \
+    tm3-hb8-9-c.dtb:/tm3-hb8-9-c.dtb \
+    tm3-hb8-12-c.dtb:/tm3-hb8-12-c.dtb \
+    tm3-hb8-7-r.dtb:/tm3-hb8-7-r.dtb"
 
 IMAGE_CMD:balenaos-img:append () {
     dd if=${DEPLOY_DIR_IMAGE}/u-boot-sunxi-with-spl.bin of=${BALENA_RAW_IMG} conv=notrunc seek=8 bs=1024


### PR DESCRIPTION
Probe I2C display controllers, to determine which DTB to load. Alternatively use DTB from 'custom_fdt_file' variable, if specified and power on wifi adapter

Changelog-entry: Determine correct DTB automatically